### PR TITLE
add ike crypto default

### DIFF
--- a/scripts/baseline_config.xml
+++ b/scripts/baseline_config.xml
@@ -32,6 +32,110 @@
         <interface>
           <ethernet/>
         </interface>
+        <ike>
+         <crypto-profiles>
+           <ike-crypto-profiles>
+             <entry name="default">
+               <encryption>
+                 <member>aes-128-cbc</member>
+                 <member>3des</member>
+               </encryption>
+               <hash>
+                 <member>sha1</member>
+               </hash>
+               <dh-group>
+                 <member>group2</member>
+               </dh-group>
+               <lifetime>
+                 <hours>8</hours>
+               </lifetime>
+             </entry>
+             <entry name="Suite-B-GCM-128">
+               <encryption>
+                 <member>aes-128-cbc</member>
+               </encryption>
+               <hash>
+                 <member>sha256</member>
+               </hash>
+               <dh-group>
+                 <member>group19</member>
+               </dh-group>
+               <lifetime>
+                 <hours>8</hours>
+               </lifetime>
+             </entry>
+             <entry name="Suite-B-GCM-256">
+               <encryption>
+                 <member>aes-256-cbc</member>
+               </encryption>
+               <hash>
+                 <member>sha384</member>
+               </hash>
+               <dh-group>
+                 <member>group20</member>
+               </dh-group>
+               <lifetime>
+                 <hours>8</hours>
+               </lifetime>
+             </entry>
+           </ike-crypto-profiles>
+           <ipsec-crypto-profiles>
+             <entry name="default">
+               <esp>
+                 <encryption>
+                   <member>aes-128-cbc</member>
+                   <member>3des</member>
+                 </encryption>
+                 <authentication>
+                   <member>sha1</member>
+                 </authentication>
+               </esp>
+               <dh-group>group2</dh-group>
+               <lifetime>
+                 <hours>1</hours>
+               </lifetime>
+             </entry>
+             <entry name="Suite-B-GCM-128">
+               <esp>
+                 <encryption>
+                   <member>aes-128-gcm</member>
+                 </encryption>
+                 <authentication>
+                   <member>none</member>
+                 </authentication>
+               </esp>
+               <dh-group>group19</dh-group>
+               <lifetime>
+                 <hours>1</hours>
+               </lifetime>
+             </entry>
+             <entry name="Suite-B-GCM-256">
+               <esp>
+                 <encryption>
+                   <member>aes-256-gcm</member>
+                 </encryption>
+                 <authentication>
+                   <member>none</member>
+                 </authentication>
+               </esp>
+               <dh-group>group20</dh-group>
+               <lifetime>
+                 <hours>1</hours>
+               </lifetime>
+             </entry>
+           </ipsec-crypto-profiles>
+           <global-protect-app-crypto-profiles>
+             <entry name="default">
+               <encryption>
+                 <member>aes-128-cbc</member>
+               </encryption>
+               <authentication>
+                 <member>sha1</member>
+               </authentication>
+             </entry>
+           </global-protect-app-crypto-profiles>
+         </crypto-profiles>
+        </ike>
         <profiles>
           <monitor-profile/>
         </profiles>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

add default ike crypto profiles to the baseline configuration. this is needed for ipsec config elements used in other skillets or general configuration

## Motivation and Context

baseline config is loadable but missing this key element as a default setting

## How Has This Been Tested?

quick load and commit


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
