### PR TITLE
Addition of vwire to HomeSkillet

### DIFF
--- a/panos_HomeSkillet_network_vwire/.meta-cnc.yaml
+++ b/panos_HomeSkillet_network_vwire/.meta-cnc.yaml
@@ -41,5 +41,8 @@ snippets:
   - name: zone
     xpath: /config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/zone
     file: zone.xml
+  - name: vwire
+    xpath: /config/devices/entry[@name='localhost.localdomain']/network/virtual-wire
+    file: vwire.xml
 
 

--- a/panos_HomeSkillet_network_vwire/.meta-cnc.yaml
+++ b/panos_HomeSkillet_network_vwire/.meta-cnc.yaml
@@ -44,5 +44,3 @@ snippets:
   - name: vwire
     xpath: /config/devices/entry[@name='localhost.localdomain']/network/virtual-wire
     file: vwire.xml
-
-

--- a/panos_HomeSkillet_network_vwire/.meta-cnc.yaml
+++ b/panos_HomeSkillet_network_vwire/.meta-cnc.yaml
@@ -38,9 +38,9 @@ snippets:
   - name: interface
     xpath: /config/devices/entry[@name='localhost.localdomain']/network/interface
     file: interface.xml
-  - name: virtual_router
-    xpath: /config/devices/entry[@name='localhost.localdomain']/network/virtual-router
-    file: virtual_router.xml
+  #- name: virtual_router
+  #  xpath: /config/devices/entry[@name='localhost.localdomain']/network/virtual-router
+  #  file: virtual_router.xml
   - name: zone
     xpath: /config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/zone
     file: zone.xml

--- a/panos_HomeSkillet_network_vwire/.meta-cnc.yaml
+++ b/panos_HomeSkillet_network_vwire/.meta-cnc.yaml
@@ -38,9 +38,6 @@ snippets:
   - name: interface
     xpath: /config/devices/entry[@name='localhost.localdomain']/network/interface
     file: interface.xml
-  #- name: virtual_router
-  #  xpath: /config/devices/entry[@name='localhost.localdomain']/network/virtual-router
-  #  file: virtual_router.xml
   - name: zone
     xpath: /config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/zone
     file: zone.xml

--- a/panos_HomeSkillet_network_vwire/.meta-cnc.yaml
+++ b/panos_HomeSkillet_network_vwire/.meta-cnc.yaml
@@ -1,8 +1,8 @@
 # gold security templates for top level security including threat, URL, or WF subscriptions
 # includes an additional security rule for strict file blocking of unknown url category
 
-name: homeskillet_L3network_panos_v90_aae24a56-b4fc-4387-abc5-6694db5f49ee
-label: v9.0 Step 2 - HomeSkillet network configuration - L3 simple routing
+name: homeskillet_vwire_panos_v90
+label: v9.0 Step 2 - HomeSkillet network configuration - vwire
 description: "** LOAD BASELINE FIRST ** v9.0 Home Skillet Internet Gateway network that loads after HomeSkillet baseline"
 
 type: panos
@@ -22,10 +22,6 @@ variables:
     default: ethernet1/2
     type_hint: dropdown
     source: interface_names
-  - name: IP_12
-    description: internal interface ip address
-    default: 192.168.45.20/24
-    type_hint: text
   - name: ZONE_TRUST
     description: internal zone name
     default: internal
@@ -34,19 +30,7 @@ variables:
     description: internet zone name
     default: internet
     type_hint: text
-  - name: DHCP_NETMASK
-    description: dhcp pool netmask
-    default: 255.255.255.0
-    type_hint: ip_address
-  - name: DHCP_GATEWAY
-    description: dhcp pool default gateway ip address
-    default: 192.168.10.1
-    type_hint: ip_address
-  - name: DHCP_POOL_RANGE
-    description: dhcp pool ip address range
-    default: 192.168.10.100-192.168.10.250
-    type_hint: text
-
+  
 snippets:
   - name: network_profiles-network-profiles
     xpath: /config/devices/entry[@name='localhost.localdomain']/network/profiles
@@ -60,11 +44,5 @@ snippets:
   - name: zone
     xpath: /config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/zone
     file: zone.xml
-  - name: nat-source-nat-to-untrust
-    xpath: /config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/rulebase/nat
-    file: source_nat_to_untrust.xml
-  - name: dhcp_server
-    xpath: /config/devices/entry[@name='localhost.localdomain']/network/dhcp
-    file: dhcp_server.xml
 
 

--- a/panos_HomeSkillet_network_vwire/README.md
+++ b/panos_HomeSkillet_network_vwire/README.md
@@ -4,11 +4,9 @@ This set of snippets are loaded prior to the security tier selection.
 
 The snippets included are:
 
-* interface: simple dual interface Internet Gateway model
+* interface: simple vwire interface model
 
-* virtual router: sets of basic routing with a default-gateway to the internet
-
-* zone: 2-zone model with internet and trust zones
+* * zone: 2-zone model with internet and trust zones
 
 * network profiles: management interface profile
 

--- a/panos_HomeSkillet_network_vwire/README.md
+++ b/panos_HomeSkillet_network_vwire/README.md
@@ -1,0 +1,21 @@
+# Internet Gateway template base configuration
+
+This set of snippets are loaded prior to the security tier selection.
+
+The snippets included are:
+
+* interface: simple dual interface Internet Gateway model
+
+* virtual router: sets of basic routing with a default-gateway to the internet
+
+* zone: 2-zone model with internet and trust zones
+
+* network profiles: management interface profile
+
+The MSSP can edit/append as required for their specific deployments.
+
+**NOTE**: The `zone_import_interface` snippet is used to create a mapping
+of interfaces and zones. This element is managed by the system when doing
+standard GUI/CLI edits yet required for a working xml configuration.
+
+

--- a/panos_HomeSkillet_network_vwire/interface.xml
+++ b/panos_HomeSkillet_network_vwire/interface.xml
@@ -1,7 +1,6 @@
 <ethernet>
     <entry name="{{ INTF_UNTRUST }}">
-      <layer3>
-        <virtual-wire/>
+      <virtual-wire/>
       <comment>Untrust interface using vwire</comment>
     </entry>
     <entry name="{{ INTF_TRUST }}">

--- a/panos_HomeSkillet_network_vwire/interface.xml
+++ b/panos_HomeSkillet_network_vwire/interface.xml
@@ -1,0 +1,10 @@
+<ethernet>
+    <entry name="{{ INTF_UNTRUST }}">
+      <layer3>
+        <virtual-wire/>
+      <comment>Untrust interface using vwire</comment>
+    </entry>
+    <entry name="{{ INTF_TRUST }}">
+      <virtual-wire/>
+    </entry>
+</ethernet>

--- a/panos_HomeSkillet_network_vwire/interface.xml
+++ b/panos_HomeSkillet_network_vwire/interface.xml
@@ -5,5 +5,6 @@
     </entry>
     <entry name="{{ INTF_TRUST }}">
       <virtual-wire/>
+      <comment>Trust interface using vwire</comment>
     </entry>
 </ethernet>

--- a/panos_HomeSkillet_network_vwire/network_profiles.xml
+++ b/panos_HomeSkillet_network_vwire/network_profiles.xml
@@ -1,0 +1,18 @@
+<monitor-profile>
+  <entry name="default">
+    <interval>3</interval>
+    <threshold>5</threshold>
+    <action>wait-recover</action>
+  </entry>
+</monitor-profile>
+<interface-management-profile>
+  <entry name="MSSP management untrust">
+    <ping>yes</ping>
+  </entry>
+  <entry name="MSSP management trust">
+    <https>yes</https>
+    <ssh>yes</ssh>
+    <ping>yes</ping>
+    <response-pages>yes</response-pages>
+  </entry>
+</interface-management-profile>

--- a/panos_HomeSkillet_network_vwire/vwire.xml
+++ b/panos_HomeSkillet_network_vwire/vwire.xml
@@ -1,0 +1,31 @@
+<entry name="default">
+  <protocol>
+    <bgp>
+      <enable>no</enable>
+      <dampening-profile>
+        <entry name="default">
+          <cutoff>1.25</cutoff>
+          <reuse>0.5</reuse>
+          <max-hold-time>900</max-hold-time>
+          <decay-half-life-reachable>300</decay-half-life-reachable>
+          <decay-half-life-unreachable>900</decay-half-life-unreachable>
+          <enable>yes</enable>
+        </entry>
+      </dampening-profile>
+      <routing-options>
+        <graceful-restart>
+          <enable>yes</enable>
+        </graceful-restart>
+      </routing-options>
+    </bgp>
+  </protocol>
+  <interface>
+    <member>{{ INTF_UNTRUST }}</member>
+    <member>{{ INTF_TRUST }}</member>
+  </interface>
+  <ecmp>
+    <algorithm>
+      <ip-modulo/>
+    </algorithm>
+  </ecmp>
+</entry>

--- a/panos_HomeSkillet_network_vwire/vwire.xml
+++ b/panos_HomeSkillet_network_vwire/vwire.xml
@@ -1,31 +1,4 @@
-<entry name="default">
-  <protocol>
-    <bgp>
-      <enable>no</enable>
-      <dampening-profile>
-        <entry name="default">
-          <cutoff>1.25</cutoff>
-          <reuse>0.5</reuse>
-          <max-hold-time>900</max-hold-time>
-          <decay-half-life-reachable>300</decay-half-life-reachable>
-          <decay-half-life-unreachable>900</decay-half-life-unreachable>
-          <enable>yes</enable>
-        </entry>
-      </dampening-profile>
-      <routing-options>
-        <graceful-restart>
-          <enable>yes</enable>
-        </graceful-restart>
-      </routing-options>
-    </bgp>
-  </protocol>
-  <interface>
-    <member>{{ INTF_UNTRUST }}</member>
-    <member>{{ INTF_TRUST }}</member>
-  </interface>
-  <ecmp>
-    <algorithm>
-      <ip-modulo/>
-    </algorithm>
-  </ecmp>
-</entry>
+<entry name="HomeSkillet-vwire">
+            <interface1>{{ INTF_UNTRUST }}</interface1>
+            <interface2>{{ INTF_TRUST }}</interface2>
+          </entry>

--- a/panos_HomeSkillet_network_vwire/zone.xml
+++ b/panos_HomeSkillet_network_vwire/zone.xml
@@ -1,0 +1,17 @@
+<entry name="{{ ZONE_UNTRUST }}">
+    <network>
+        <virtual-wire>
+        <member>{{ INTF_UNTRUST }}</member>
+      </virtual-wire>
+      <zone-protection-profile>Recommended_Zone_Protection</zone-protection-profile>
+    </network>
+  </entry>
+  <entry name="{{ ZONE_TRUST }}">
+    <network>
+     <virtual-wire>
+        <member>{{ INTF_TRUST }}</member>
+      </virtual-wire>
+      <zone-protection-profile>Recommended_Zone_Protection</zone-protection-profile>
+    </network>
+  </entry>
+

--- a/workflow_HomeSkillet_menu_selection/.meta-cnc.yaml
+++ b/workflow_HomeSkillet_menu_selection/.meta-cnc.yaml
@@ -51,9 +51,9 @@ variables:
     default: l3_gateway
     type_hint: dropdown
     dd_list:
-      - key: 2 interface and 2 zone L3 gateway
+      - key: Layer 3 --  2 zone 2 interface configuration
         value: l3_gateway
-      - key: 2 interface vwire
+      - key: vwire -- 2 zone vwire configuration
         value: vwire_gateway
   - name: add_options
     description: select additional HomeSkillet configuration options

--- a/workflow_HomeSkillet_menu_selection/.meta-cnc.yaml
+++ b/workflow_HomeSkillet_menu_selection/.meta-cnc.yaml
@@ -38,13 +38,13 @@ variables:
         value: load_updates
       - key: (3) validation check prior to step 1 config - see FAIL output
         value: pre_validation
-      - key: (4) load step 1 IronSkillet-based configuration (commit required for online validation test)
+      - key: (4) IronSkillet-based configuration (commit required for online validation test)
         value: load_step1
       - key: (5) validation check after day 1 load - see PASS output
         value: post_validation
-      - key: (6) load step 2 network and zone config elements
+      - key: (6) network and zone config elements
         value: load_step2
-      - key: (7) load step 3 security policy config elements
+      - key: (7) security policy config elements
         value: load_step3
   - name: network_type
     description: choose the skillet-supported network deployment type
@@ -53,6 +53,8 @@ variables:
     dd_list:
       - key: 2 interface and 2 zone L3 gateway
         value: l3_gateway
+      - key: 2 interface vwire
+        value: vwire_gateway
   - name: add_options
     description: select additional HomeSkillet configuration options
     default: []
@@ -81,9 +83,12 @@ snippets:
 # grab list of interfaces
   - name: get_interface_lists_812E106E-EF84-48CC-A2CB-96F9D7DA7296
     when: "'load_step2' in workflow_options"
-# network layer and zone configuration
+# network layer and zone configuration L3
   - name: homeskillet_L3network_panos_v90_aae24a56-b4fc-4387-abc5-6694db5f49ee
     when: "'load_step2' in workflow_options and network_type == 'l3_gateway'"
+# network layer and zone configuration vwire
+  - name: homeskillet_vwire_panos_v90
+    when: "'load_step2' in workflow_options and network_type == 'vwire_gateway'"
 # grab list of zones
   - name: get_zone_names_812E106E-EF84-48CC-A2CB-96F9D7DA7296
     when: "'load_step3' in workflow_options"

--- a/workflow_HomeSkillet_menu_selection/.meta-cnc.yaml
+++ b/workflow_HomeSkillet_menu_selection/.meta-cnc.yaml
@@ -42,7 +42,7 @@ variables:
         value: load_step1
       - key: (5) validation check after day 1 load - see PASS output
         value: post_validation
-      - key: (6) network and zone config elements
+      - key: (6) network and zone config elements  (choose your networking option below)
         value: load_step2
       - key: (7) security policy config elements
         value: load_step3
@@ -51,9 +51,9 @@ variables:
     default: l3_gateway
     type_hint: dropdown
     dd_list:
-      - key: Layer 3 --  2 zone 2 interface configuration
+      - key: Layer 3 --  2 zone & 2 interface configuration
         value: l3_gateway
-      - key: vwire -- 2 zone vwire configuration
+      - key: vwire -- 2 zone & vwire configuration
         value: vwire_gateway
   - name: add_options
     description: select additional HomeSkillet configuration options


### PR DESCRIPTION
Additional of vwire option to HomeSkillet
## Description
Added a new panos_homeSkillet_network_vwire  folder/content to HomeSkillet
Removed any infrastructure not required by vwire configuration
Update text to reflect vwire instead of L3
Added DHCP server option back into Layer3 metacnc file
Removed some confusing text from the workflow menus

## Motivation and Context
vwire support required by many SEs that run cable connections to their homes.

## How Has This Been Tested?
Tested against PA-220 running 9.0.4 and 9.0.7
Tested original functionality -- passed
Tested vwire functionality -- passed.  This included running live traffic through the vwire configured firewall
Tested switching back/forth between vwire/layer3/base_config in various combinations

## Screenshots (if appropriate)

<!--- Drag any screenshots here -->

