### PR TITLE
update WF file size limits per IronSkillet update

### DIFF
--- a/panos_HomeSkillet_step1_base/device_setting.xml
+++ b/panos_HomeSkillet_step1_base/device_setting.xml
@@ -21,18 +21,18 @@
   <auto-acquire-commit-lock>yes</auto-acquire-commit-lock>
 </management>
 <wildfire>
-  <file-size-limit>
+   <file-size-limit>
     <entry name="pe">
-      <size-limit>10</size-limit>
+      <size-limit>16</size-limit>
     </entry>
     <entry name="apk">
       <size-limit>30</size-limit>
     </entry>
     <entry name="pdf">
-      <size-limit>1000</size-limit>
+      <size-limit>3072</size-limit>
     </entry>
     <entry name="ms-office">
-      <size-limit>2000</size-limit>
+      <size-limit>16384</size-limit>
     </entry>
     <entry name="jar">
       <size-limit>5</size-limit>
@@ -41,18 +41,18 @@
       <size-limit>5</size-limit>
     </entry>
     <entry name="MacOSX">
-      <size-limit>1</size-limit>
-    </entry>
-    <entry name="archive">
       <size-limit>10</size-limit>
     </entry>
+    <entry name="archive">
+      <size-limit>50</size-limit>
+    </entry>
     <entry name="linux">
-      <size-limit>2</size-limit>
+      <size-limit>50</size-limit>
     </entry>
     <entry name="script">
       <size-limit>2000</size-limit>
     </entry>
-  </file-size-limit>
+   </file-size-limit>
   <report-benign-file>yes</report-benign-file>
   <report-grayware-file>yes</report-grayware-file>
 </wildfire>

--- a/panos_HomeSkillet_step1_base/tag.xml
+++ b/panos_HomeSkillet_step1_base/tag.xml
@@ -8,5 +8,5 @@
 	<comments>Internal to Internal</comments>
 </entry>
 <entry name="iron-skillet-version">
-	<comments>version 0.0.4 for 9.0: version of this IronSkillet template file</comments>
+	<comments>version 0.0.5 for 9.0: version of this IronSkillet template file</comments>
 </entry>


### PR DESCRIPTION
change values in device_setting.xml to match updated values in IronSkillet. This is recommended changes to match to the BPA values in 9.x

Also updated the tag.xml file with the new IronSkillet version of 0.0.5

Quick test by loading the skillet with panHandler to validation no loading errors.