### PR TITLE
Bug Fix and Submodule Update

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "submodules/ironskillet-components"]
 	path = submodules/ironskillet-components
 	url = https://github.com/PaloAltoNetworks/ironskillet-components
-[submodule "submodules/panos-ansible-upgrade-downgrade"]
-	path = submodules/panos-ansible-upgrade-downgrade
-	url = https://github.com/PaloAltoNetworks/panos-ansible-upgrade-downgrade.git
 [submodule "submodules/panos-config-elements"]
 	path = submodules/panos-config-elements
 	url = https://github.com/pan-community/panos-config-elements.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,7 @@
 [submodule "submodules/panos-config-elements"]
 	path = submodules/panos-config-elements
 	url = https://github.com/pan-community/panos-config-elements.git
+[submodule "submodules/panos-ansible-upgrade-downgrade"]
+	path = submodules/panos-ansible-upgrade-downgrade
+	url = git@github.com:PaloAltoNetworks/panos-ansible-upgrade-downgrade.git
+	branch = main


### PR DESCRIPTION
Updated files within the panos-upgrade-downgrade submodule to point to dockerhub instead of Gitlab registry. Also updated the submodule folder to point to the -main branch of panos-upgrade-downgrade.